### PR TITLE
INVAPI-9 add location endpoints

### DIFF
--- a/api.swagger.yaml
+++ b/api.swagger.yaml
@@ -781,7 +781,7 @@ definitions:
       phone:
         description: The location's telephone number.
         type: string
-        example: +44 123456789
+        example: +1-23-456-789
       email:
         description: The location's email address.
         type: string

--- a/api.swagger.yaml
+++ b/api.swagger.yaml
@@ -269,6 +269,152 @@ paths:
             than a duplicate username or email address) or JSON schema
             validation failure.
       description: Update the user's information.
+  '/users/{user_id}/job_roles':
+    get:
+      description: List the user's job roles.
+      parameters:
+        - in: path
+          name: user_id
+          type: string
+          description: The Invotra UUID of the user.
+          required: true
+      responses:
+        '200':
+          description: >
+            List of job roles associated with the user, or an empty array if the
+            user has no job roles.
+          schema:
+            $ref: '#/definitions/uuid-list-schema'
+        '400':
+          description: The supplied UUID was malformed.
+        '404':
+          description: The UUID does not correspond to an existing user.
+  '/users/{user_id}/job_roles/{job_role_id}':
+    delete:
+      description: Remove a job role from a user.
+      parameters:
+        - description: The Invotra UUID of the user.
+          in: path
+          name: user_id
+          pattern: >-
+            ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
+          required: true
+          type: string
+        - description: The Invotra UUID of the job role.
+          in: path
+          name: job_role_id
+          pattern: >-
+            ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
+          required: true
+          type: string
+      responses:
+        '200':
+          description: The job role has been removed from the user.
+        '400':
+          description: One or both of the UUIDs was malformed.
+        '404':
+          description: >
+            The user or job role does not exist, or the user did not have that
+            job role.
+    put:
+      description: Add a job role to a user.
+      parameters:
+        - description: The Invotra UUID of the user.
+          in: path
+          name: user_id
+          pattern: >-
+            ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
+          required: true
+          type: string
+        - description: The Invotra UUID of the job role.
+          in: path
+          name: job_role_id
+          pattern: >-
+            ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
+          required: true
+          type: string
+      responses:
+        '200':
+          description: The user already has this job role.
+        '201':
+          description: The job role was added to the user.
+        '400':
+          description: One or both of the UUIDs was malformed.
+        '404':
+          description: The user or job role does not exist.
+  '/users/{user_id}/locations':
+    get:
+      description: List the user's locations.
+      parameters:
+        - in: path
+          name: user_id
+          type: string
+          description: The Invotra UUID of the user.
+          required: true
+      responses:
+        '200':
+          description: >
+            List of locations associated with the user, or an empty array if the
+            user has no locations.
+          schema:
+            $ref: '#/definitions/uuid-list-schema'
+        '400':
+          description: The supplied UUID was malformed.
+        '404':
+          description: The UUID does not correspond to an existing user.
+  '/users/{user_id}/locations/{location_id}':
+    delete:
+      description: Remove a location from a user.
+      parameters:
+        - description: The Invotra UUID of the user.
+          in: path
+          name: user_id
+          pattern: >-
+            ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
+          required: true
+          type: string
+        - description: The Invotra UUID of the location.
+          in: path
+          name: location_id
+          pattern: >-
+            ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
+          required: true
+          type: string
+      responses:
+        '200':
+          description: The location has been removed from the user.
+        '400':
+          description: One or both of the UUIDs was malformed.
+        '404':
+          description: >
+            The user or location does not exist, or the user did not have that
+            location.
+    put:
+      description: Add a location to a user.
+      parameters:
+        - description: The Invotra UUID of the user.
+          in: path
+          name: user_id
+          pattern: >-
+            ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
+          required: true
+          type: string
+        - description: The Invotra UUID of the job role.
+          in: path
+          name: location_id
+          pattern: >-
+            ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
+          required: true
+          type: string
+      responses:
+        '200':
+          description: The user already has this location.
+        '201':
+          description: The location was added to the user.
+        '400':
+          description: One or both of the UUIDs was malformed.
+        '404':
+          description: The user or location does not exist.
   /job_roles:
     get:
       parameters:

--- a/api.swagger.yaml
+++ b/api.swagger.yaml
@@ -365,18 +365,19 @@ paths:
       responses:
         '200':
           description: >
-            List of locations matching the filter criteria, or an empty array of
+            List of locations matching the filter criteria, or an empty array if
             none were found.
           schema:
-            $ref: '#/definitions/uuid-list-schema'
+            $ref: '#/definitions/location-uuid-list-schema'
       description: Search for locations.
+  /locations/sites:
     post:
       parameters:
         - in: body
           name: body
           required: true
           schema:
-            $ref: '#/definitions/location-schema-create'
+            $ref: '#/definitions/location-site-schema-create'
       responses:
         '201':
           description: The location was created successfully.
@@ -393,7 +394,7 @@ paths:
             The location was not saved due to Drupal validation failure or JSON
             schema validation failure.
       description: Provision a new location.
-  '/locations/{location_id}':
+  '/locations/sites/{location_id}':
     get:
       parameters:
         - description: The Invotra UUID of the location.
@@ -407,7 +408,7 @@ paths:
         '200':
           description: Returns a single complete location object.
           schema:
-            $ref: '#/definitions/location-schema'
+            $ref: '#/definitions/location-site-schema'
         '400':
           description: The supplied UUID was malformed.
         '404':
@@ -426,7 +427,7 @@ paths:
           name: body
           required: true
           schema:
-            $ref: '#/definitions/location-schema'
+            $ref: '#/definitions/location-site-schema'
       responses:
         '200':
           description: The location information was updated successfully.
@@ -590,7 +591,8 @@ definitions:
       - $ref: '#definitions/job-role-schema'
     required:
       - title
-  location-schema:
+  location-site-schema:
+    type: object
     properties:
       title:
         description: This is the name of the location.
@@ -604,27 +606,56 @@ definitions:
         description: This is used to store the location's external reference id.
         type: string
         example: ABC123
+      type:
+        description: The location type.
+        type: string
+        enum:
+          - site
+          - building
+          - floor
+          - space
       parent_uuid:
         description: This is the Invotra UUID of the parent location.
         pattern: >-
-          ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
+          ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0 
+          -9]{12}$
         type: string
         example: 01234567-89ab-cdef-1234-56789abcdef0
-    type: object
-  location-schema-create:
+  location-site-schema-create:
     allOf:
-      - $ref: '#definitions/location-schema'
+      - $ref: '#definitions/location-site-schema'
     required:
       - title
   uuid-list-schema:
     items:
-      default: 00000000-0000-0000-0000-000000000000
       description: An array of UUIDs.
       pattern: >-
         ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
       type: string
       example: 01234567-89ab-cdef-1234-56789abcdef0
     type: array
+  location-uuid-list-schema:
+    type: array
+    items:
+      type: object
+      properties:
+        uuid:
+          description: The UUID of the location.
+          type: string
+          pattern: >-
+            ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
+          example: 01234567-89ab-cdef-1234-56789abcdef0
+        type:
+          description: The location type.
+          type: string
+          enum:
+            - site
+            - building
+            - floor
+            - space
+      required:
+        - uuid
+        - type
 securityDefinitions:
   APIKeyHeader:
     type: apiKey

--- a/api.swagger.yaml
+++ b/api.swagger.yaml
@@ -854,7 +854,7 @@ definitions:
     type: object
   team-schema-create:
     allOf:
-      - $ref: '#definitions/team-schema'
+      - $ref: '#/definitions/team-schema'
     required:
       - title
     type: object
@@ -930,7 +930,7 @@ definitions:
     type: object
   user-schema-create:
     allOf:
-      - $ref: '#definitions/user-schema'
+      - $ref: '#/definitions/user-schema'
     required:
       - email
       - username
@@ -958,7 +958,7 @@ definitions:
     type: object
   job-role-schema-create:
     allOf:
-      - $ref: '#definitions/job-role-schema'
+      - $ref: '#/definitions/job-role-schema'
     required:
       - title
   location-common-schema:
@@ -1017,12 +1017,12 @@ definitions:
             format: email
   location-site-schema-create:
     allOf:
-      - $ref: '#definitions/location-site-schema'
+      - $ref: '#/definitions/location-site-schema'
     required:
       - title
   location-building-schema:
     allOf:
-      - $ref: '#definitions/location-site-schema'
+      - $ref: '#/definitions/location-site-schema'
       - type: object
         properties:
           parent_uuid:
@@ -1035,12 +1035,12 @@ definitions:
             example: 01234567-89ab-cdef-1234-56789abcdef0
   location-building-schema-create:
     allOf:
-      - $ref: '#definitions/location-building-schema'
+      - $ref: '#/definitions/location-building-schema'
     required:
       - title
   location-floor-schema:
     allOf:
-      - $ref: '#definitions/location-common-schema'
+      - $ref: '#/definitions/location-common-schema'
       - type: object
         properties:
           parent_uuid:
@@ -1053,12 +1053,12 @@ definitions:
             example: 01234567-89ab-cdef-1234-56789abcdef0
   location-floor-schema-create:
     allOf:
-      - $ref: '#definitions/location-floor-schema'
+      - $ref: '#/definitions/location-floor-schema'
     required:
       - title
   location-space-schema:
     allOf:
-      - $ref: '#definitions/location-common-schema'
+      - $ref: '#/definitions/location-common-schema'
       - type: object
         properties:
           parent_uuid:
@@ -1071,7 +1071,7 @@ definitions:
             example: 01234567-89ab-cdef-1234-56789abcdef0
   location-space-schema-create:
     allOf:
-      - $ref: '#definitions/location-space-schema'
+      - $ref: '#/definitions/location-space-schema'
     required:
       - title
   uuid-list-schema:
@@ -1150,7 +1150,7 @@ definitions:
   team-team-membership-list-schema:
     type: array
     items:
-      $ref: '#definitions/team-team-membership-schema'
+      $ref: '#/definitions/team-team-membership-schema'
 securityDefinitions:
   APIKeyHeader:
     type: apiKey

--- a/api.swagger.yaml
+++ b/api.swagger.yaml
@@ -735,7 +735,7 @@ definitions:
       - $ref: '#definitions/job-role-schema'
     required:
       - title
-  location-site-schema:
+  location-common-schema:
     type: object
     properties:
       title:
@@ -750,40 +750,45 @@ definitions:
         description: This is used to store the location's external reference id.
         type: string
         example: ABC123
-      address1:
-        description: The first line of the location's postal address.
-        type: string
-        example: 1 Main Street
-      address2:
-        description: The second line of the location's postal address.
-        type: string
-        example: Littleton Village
-      address3:
-        description: The third line of the location's postal address.
-        type: string
-        example: Northern District
-      town:
-        description: The town where the location is.
-        type: string
-        example: Metropolis
-      postcode:
-        description: 'The location''s postal code or zip code, if any.'
-        type: string
-        example: ABC 123
-      team:
-        description: A team associated with the location.
-        type: string
-        pattern: >-
-          ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
-        example: 01234567-89ab-cdef-1234-56789abcdef0
-      phone:
-        description: The location's telephone number.
-        type: string
-        example: +1-23-456-789
-      email:
-        description: The location's email address.
-        type: string
-        format: email
+  location-site-schema:
+    allOf:
+      - $ref: '#/definitions/location-common-schema'
+      - type: object
+        properties:
+          address1:
+            description: The first line of the location's postal address.
+            type: string
+            example: 1 Main Street
+          address2:
+            description: The second line of the location's postal address.
+            type: string
+            example: Littleton Village
+          address3:
+            description: The third line of the location's postal address.
+            type: string
+            example: Northern District
+          town:
+            description: The town where the location is.
+            type: string
+            example: Metropolis
+          postcode:
+            description: 'The location''s postal code or zip code, if any.'
+            type: string
+            example: ABC 123
+          team:
+            description: A team associated with the location.
+            type: string
+            pattern: >-
+              ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
+            example: 01234567-89ab-cdef-1234-56789abcdef0
+          phone:
+            description: The location's telephone number.
+            type: string
+            example: +1-23-456-789
+          email:
+            description: The location's email address.
+            type: string
+            format: email
   location-site-schema-create:
     allOf:
       - $ref: '#definitions/location-site-schema'
@@ -796,8 +801,8 @@ definitions:
         properties:
           parent_uuid:
             description: >
-              This is the Invotra UUID of the parent location. This location
-              must be a site.
+              The Invotra UUID of the parent location. This location must be a
+              site.
             pattern: >-
               ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
             type: string
@@ -805,6 +810,42 @@ definitions:
   location-building-schema-create:
     allOf:
       - $ref: '#definitions/location-building-schema'
+    required:
+      - title
+  location-floor-schema:
+    allOf:
+      - $ref: '#definitions/location-common-schema'
+      - type: object
+        properties:
+          parent_uuid:
+            description: >
+              The Invotra UUID of the parent location. This location must be a
+              building.
+            pattern: >-
+              ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
+            type: string
+            example: 01234567-89ab-cdef-1234-56789abcdef0
+  location-floor-schema-create:
+    allOf:
+      - $ref: '#definitions/location-floor-schema'
+    required:
+      - title
+  location-space-schema:
+    allOf:
+      - $ref: '#definitions/location-space-schema'
+      - type: object
+        properties:
+          parent_uuid:
+            description: >
+              The Invotra UUID of the parent location. This location must be a
+              floor.
+            pattern: >-
+              ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
+            type: string
+            example: 01234567-89ab-cdef-1234-56789abcdef0
+  location-space-schema-create:
+    allOf:
+      - $ref: '#definitions/location-space-schema'
     required:
       - title
   uuid-list-schema:

--- a/api.swagger.yaml
+++ b/api.swagger.yaml
@@ -606,21 +606,40 @@ definitions:
         description: This is used to store the location's external reference id.
         type: string
         example: ABC123
-      type:
-        description: The location type.
+      address1:
+        description: The first line of the location's postal address.
         type: string
-        enum:
-          - site
-          - building
-          - floor
-          - space
-      parent_uuid:
-        description: This is the Invotra UUID of the parent location.
+        example: 1 Main Street
+      address2:
+        description: The second line of the location's postal address.
+        type: string
+        example: Littleton Village
+      address3:
+        description: The third line of the location's postal address.
+        type: string
+        example: Northern District
+      town:
+        description: The town where the location is.
+        type: string
+        example: Metropolis
+      postcode:
+        description: 'The location''s postal code or zip code, if any.'
+        type: string
+        example: ABC 123
+      team:
+        description: A team associated with the location.
+        type: string
         pattern: >-
-          ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0 
-          -9]{12}$
-        type: string
+          ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
         example: 01234567-89ab-cdef-1234-56789abcdef0
+      phone:
+        description: The location's telephone number.
+        type: string
+        example: +44 123456789
+      email:
+        description: The location's email address.
+        type: string
+        format: email
   location-site-schema-create:
     allOf:
       - $ref: '#definitions/location-site-schema'

--- a/api.swagger.yaml
+++ b/api.swagger.yaml
@@ -1082,28 +1082,30 @@ definitions:
       type: string
       example: 01234567-89ab-cdef-1234-56789abcdef0
     type: array
+  location-uuid-schema:
+    type: object
+    properties:
+      uuid:
+        description: The UUID of the location.
+        type: string
+        pattern: >-
+          ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
+        example: 01234567-89ab-cdef-1234-56789abcdef0
+      type:
+        description: The location type.
+        type: string
+        enum:
+          - site
+          - building
+          - floor
+          - space
+    required:
+      - uuid
+      - type
   location-uuid-list-schema:
     type: array
     items:
-      type: object
-      properties:
-        uuid:
-          description: The UUID of the location.
-          type: string
-          pattern: >-
-            ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
-          example: 01234567-89ab-cdef-1234-56789abcdef0
-        type:
-          description: The location type.
-          type: string
-          enum:
-            - site
-            - building
-            - floor
-            - space
-      required:
-        - uuid
-        - type
+      $ref: '#/definitions/location-uuid-schema'
   team-membership-schema:
     type: object
     properties:

--- a/api.swagger.yaml
+++ b/api.swagger.yaml
@@ -791,6 +791,24 @@ definitions:
       - $ref: '#definitions/location-site-schema'
     required:
       - title
+  location-building-schema:
+    allOf:
+      - $ref: '#definitions/location-site-schema'
+      - type: object
+        properties:
+          parent_uuid:
+            description: >
+              This is the Invotra UUID of the parent location. This location
+              must be a site.
+            pattern: >-
+              ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
+            type: string
+            example: 01234567-89ab-cdef-1234-56789abcdef0
+  location-building-schema-create:
+    allOf:
+      - $ref: '#definitions/location-building-schema'
+    required:
+      - title
   uuid-list-schema:
     items:
       description: An array of UUIDs.

--- a/api.swagger.yaml
+++ b/api.swagger.yaml
@@ -108,7 +108,7 @@ paths:
           description: |
             List of team members. If there are no members, an empty array.
           schema:
-            $ref: '#/definitions/team-membership-list-schema'
+            $ref: '#/definitions/team-team-membership-list-schema'
         '400':
           description: The supplied UUID was malformed.
         '404':
@@ -161,7 +161,7 @@ paths:
           name: body
           required: true
           schema:
-            $ref: '#/definitions/team-membership-schema'
+            $ref: '#/definitions/team-team-membership-schema'
       responses:
         '200':
           description: The user's membership of this team was updated.
@@ -428,7 +428,7 @@ paths:
             membership type (admin or member) for each team. If the user is not
             a member of any teams, an empty array is returned.
           schema:
-            $ref: '#/definitions/user-team-membership-schema'
+            $ref: '#/definitions/user-team-membership-list-schema'
         '400':
           description: The supplied UUID was malformed.
         '404':
@@ -1106,7 +1106,7 @@ definitions:
     type: array
     items:
       $ref: '#/definitions/location-uuid-schema'
-  team-membership-schema:
+  team-membership-common-schema:
     type: object
     properties:
       type:
@@ -1118,35 +1118,39 @@ definitions:
     required:
       - type
   user-team-membership-schema:
+    allOf:
+      - $ref: '#/definitions/team-membership-common-schema'
+      - type: object
+        properties:
+          uuid:
+            description: The UUID of the team.
+            type: string
+            pattern: >-
+              ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
+            example: 01234567-89ab-cdef-1234-56789abcdef0
+        required:
+          - uuid
+  user-team-membership-list-schema:
     type: array
     items:
-      allOf:
-        - $ref: '#/definitions/team-membership-schema'
-        - type: object
-          properties:
-            uuid:
-              description: The UUID of the team.
-              type: string
-              pattern: >-
-                ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
-              example: 01234567-89ab-cdef-1234-56789abcdef0
-          required:
-            - uuid
-  team-membership-list-schema:
+      $ref: '#/definitions/user-team-membership-schema'
+  team-team-membership-schema:
+    allOf:
+      - $ref: '#/definitions/team-membership-common-schema'
+      - type: object
+        properties:
+          uuid:
+            description: The UUID of the user.
+            type: string
+            pattern: >-
+              ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
+            example: 01234567-89ab-cdef-1234-56789abcdef0
+        required:
+          - uuid
+  team-team-membership-list-schema:
     type: array
     items:
-      allOf:
-        - $ref: '#/definitions/team-membership-schema'
-        - type: object
-          properties:
-            uuid:
-              description: The UUID of the user.
-              type: string
-              pattern: >-
-                ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
-              example: 01234567-89ab-cdef-1234-56789abcdef0
-          required:
-            - uuid
+      $ref: '#definitions/team-team-membership-schema'
 securityDefinitions:
   APIKeyHeader:
     type: apiKey

--- a/api.swagger.yaml
+++ b/api.swagger.yaml
@@ -576,7 +576,9 @@ paths:
         '400':
           description: The supplied UUID was malformed.
         '404':
-          description: The UUID does not correspond to an existing location.
+          description: >-
+            The UUID does not correspond to an existing location, or the
+            location is not a site.
       description: Get information about the location.
     put:
       parameters:
@@ -598,7 +600,231 @@ paths:
         '400':
           description: The supplied UUID or JSON was malformed.
         '404':
-          description: The UUID does not correspond to an existing location.
+          description: >-
+            The UUID does not correspond to an existing location, or the
+            location is not a site.
+        '422':
+          description: |
+            The location was not updated due to a Drupal validation failure or a
+            JSON schema validation failure.
+      description: Update location information.
+  /locations/buildings:
+    post:
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            $ref: '#/definitions/location-building-schema-create'
+      responses:
+        '201':
+          description: The location was created successfully.
+          headers:
+            Location:
+              type: string
+              description: >
+                The URL at which the newly provisioned location may be
+                retrieved.
+        '400':
+          description: The location was not saved due to malformed JSON.
+        '422':
+          description: |
+            The location was not saved due to Drupal validation failure or JSON
+            schema validation failure.
+      description: Provision a new location.
+  '/locations/buildings/{location_id}':
+    get:
+      parameters:
+        - description: The Invotra UUID of the location.
+          in: path
+          name: location_id
+          pattern: >-
+            ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Returns a single complete location object.
+          schema:
+            $ref: '#/definitions/location-building-schema'
+        '400':
+          description: The supplied UUID was malformed.
+        '404':
+          description: >-
+            The UUID does not correspond to an existing location, or the
+            location is not a building.
+      description: Get information about the location.
+    put:
+      parameters:
+        - description: The Invotra UUID of the location.
+          in: path
+          name: location_id
+          pattern: >-
+            ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
+          required: true
+          type: string
+        - in: body
+          name: body
+          required: true
+          schema:
+            $ref: '#/definitions/location-building-schema'
+      responses:
+        '200':
+          description: The location information was updated successfully.
+        '400':
+          description: The supplied UUID or JSON was malformed.
+        '404':
+          description: >-
+            The UUID does not correspond to an existing location, or the
+            location is not a building.
+        '422':
+          description: |
+            The location was not updated due to a Drupal validation failure or a
+            JSON schema validation failure.
+      description: Update location information.
+  /locations/floors:
+    post:
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            $ref: '#/definitions/location-floor-schema-create'
+      responses:
+        '201':
+          description: The location was created successfully.
+          headers:
+            Location:
+              type: string
+              description: >
+                The URL at which the newly provisioned location may be
+                retrieved.
+        '400':
+          description: The location was not saved due to malformed JSON.
+        '422':
+          description: |
+            The location was not saved due to Drupal validation failure or JSON
+            schema validation failure.
+      description: Provision a new location.
+  '/locations/floors/{location_id}':
+    get:
+      parameters:
+        - description: The Invotra UUID of the location.
+          in: path
+          name: location_id
+          pattern: >-
+            ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Returns a single complete location object.
+          schema:
+            $ref: '#/definitions/location-floor-schema'
+        '400':
+          description: The supplied UUID was malformed.
+        '404':
+          description: >-
+            The UUID does not correspond to an existing location, or the
+            location is not a floor.
+      description: Get information about the location.
+    put:
+      parameters:
+        - description: The Invotra UUID of the location.
+          in: path
+          name: location_id
+          pattern: >-
+            ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
+          required: true
+          type: string
+        - in: body
+          name: body
+          required: true
+          schema:
+            $ref: '#/definitions/location-floor-schema'
+      responses:
+        '200':
+          description: The location information was updated successfully.
+        '400':
+          description: The supplied UUID or JSON was malformed.
+        '404':
+          description: >-
+            The UUID does not correspond to an existing location, or the
+            location is not a floor.
+        '422':
+          description: |
+            The location was not updated due to a Drupal validation failure or a
+            JSON schema validation failure.
+      description: Update location information.
+  /locations/spaces:
+    post:
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            $ref: '#/definitions/location-space-schema-create'
+      responses:
+        '201':
+          description: The location was created successfully.
+          headers:
+            Location:
+              type: string
+              description: >
+                The URL at which the newly provisioned location may be
+                retrieved.
+        '400':
+          description: The location was not saved due to malformed JSON.
+        '422':
+          description: |
+            The location was not saved due to Drupal validation failure or JSON
+            schema validation failure.
+      description: Provision a new location.
+  '/locations/spaces/{location_id}':
+    get:
+      parameters:
+        - description: The Invotra UUID of the location.
+          in: path
+          name: location_id
+          pattern: >-
+            ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Returns a single complete location object.
+          schema:
+            $ref: '#/definitions/location-space-schema'
+        '400':
+          description: The supplied UUID was malformed.
+        '404':
+          description: >-
+            The UUID does not correspond to an existing location, or the
+            location is not a space.
+      description: Get information about the location.
+    put:
+      parameters:
+        - description: The Invotra UUID of the location.
+          in: path
+          name: location_id
+          pattern: >-
+            ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
+          required: true
+          type: string
+        - in: body
+          name: body
+          required: true
+          schema:
+            $ref: '#/definitions/location-space-schema'
+      responses:
+        '200':
+          description: The location information was updated successfully.
+        '400':
+          description: The supplied UUID or JSON was malformed.
+        '404':
+          description: >-
+            The UUID does not correspond to an existing location, or the
+            location is not a space.
         '422':
           description: |
             The location was not updated due to a Drupal validation failure or a
@@ -832,7 +1058,7 @@ definitions:
       - title
   location-space-schema:
     allOf:
-      - $ref: '#definitions/location-space-schema'
+      - $ref: '#definitions/location-common-schema'
       - type: object
         properties:
           parent_uuid:

--- a/api.swagger.yaml
+++ b/api.swagger.yaml
@@ -1,9 +1,9 @@
 swagger: '2.0'
 info:
   title: InvotraAPI
-  version: v0.2
+  version: v0.3
 host: api.invotra.com
-basePath: /v0.2
+basePath: /v0.3
 schemes:
   - https
 security:
@@ -31,10 +31,15 @@ paths:
           name: body
           required: true
           schema:
-            $ref: '#/definitions/team-schema'
+            $ref: '#/definitions/team-schema-create'
       responses:
         '201':
           description: The team was created successfully.
+          headers:
+            Location:
+              type: string
+              description: |
+                The URL at which the newly provisioned team may be retrieved.
         '400':
           description: The team was not saved due to malformed JSON.
         '422':
@@ -42,13 +47,14 @@ paths:
             The team was not saved due to Drupal validation failure or JSON
             schema validation failure.
       description: Provision a new team.
-  '/teams/{teamId}':
+  '/teams/{team_id}':
     get:
       parameters:
         - description: The Invotra UUID of the team.
           in: path
-          name: teamId
-          pattern: '^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$'
+          name: team_id
+          pattern: >-
+            ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
           required: true
           type: string
       responses:
@@ -65,15 +71,16 @@ paths:
       parameters:
         - description: The Invotra UUID of the team.
           in: path
-          name: teamId
-          pattern: '^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$'
+          name: team_id
+          pattern: >-
+            ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
           required: true
           type: string
         - in: body
           name: body
           required: true
           schema:
-            $ref: '#/definitions/team-schema-create'
+            $ref: '#/definitions/team-schema'
       responses:
         '200':
           description: The team information was updated successfully.
@@ -86,13 +93,14 @@ paths:
             The team was not updated due to a Drupal validation failure or a
             JSON schema validation failure.
       description: Update team information.
-  '/teams/{teamId}/memberships':
+  '/teams/{team_id}/memberships':
     get:
       parameters:
         - description: The Invotra UUID of the team.
           in: path
-          name: teamId
-          pattern: '^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$'
+          name: team_id
+          pattern: >-
+            ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
           required: true
           type: string
       responses:
@@ -106,19 +114,21 @@ paths:
         '404':
           description: The UUID does not correspond to an existing team.
       description: Get a list of team members.
-  '/teams/{teamId}/memberships/{userId}':
+  '/teams/{team_id}/memberships/{user_id}':
     delete:
       parameters:
         - description: The Invotra UUID of the team.
           in: path
-          name: teamId
-          pattern: '^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$'
+          name: team_id
+          pattern: >-
+            ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
           required: true
           type: string
         - description: The Invotra UUID of the user.
           in: path
-          name: userId
-          pattern: '^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$'
+          name: user_id
+          pattern: >-
+            ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
           required: true
           type: string
       responses:
@@ -135,14 +145,16 @@ paths:
       parameters:
         - description: The Invotra UUID of the team.
           in: path
-          name: teamId
-          pattern: '^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$'
+          name: team_id
+          pattern: >-
+            ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
           required: true
           type: string
         - description: The Invotra UUID of the user.
           in: path
-          name: userId
-          pattern: '^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$'
+          name: user_id
+          pattern: >-
+            ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
           required: true
           type: string
         - default: member
@@ -189,6 +201,11 @@ paths:
       responses:
         '201':
           description: The user was created successfully.
+          headers:
+            Location:
+              type: string
+              description: |
+                The URL at which the newly provisioned user may be retrieved.
         '400':
           description: The user was not saved due to malformed JSON.
         '409':
@@ -201,13 +218,14 @@ paths:
             a duplicate username or email address) or JSON schema validation
             failure.
       description: Provision a new user in Invotra.
-  '/users/{userId}':
+  '/users/{user_id}':
     get:
       parameters:
         - description: The Invotra UUID of the user.
           in: path
-          name: userId
-          pattern: '^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$'
+          name: user_id
+          pattern: >-
+            ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
           required: true
           type: string
       responses:
@@ -224,15 +242,16 @@ paths:
       parameters:
         - description: The Invotra UUID of the user.
           in: path
-          name: userId
-          pattern: '^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$'
+          name: user_id
+          pattern: >-
+            ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
           required: true
           type: string
         - in: body
           name: body
           required: true
           schema:
-            $ref: '#/definitions/user-schema-update'
+            $ref: '#/definitions/user-schema'
       responses:
         '200':
           description: The user's information was updated.
@@ -260,11 +279,11 @@ paths:
           type: string
       responses:
         '200':
-          description: List of job roles matching the filter criteria.
+          description: >
+            List of job roles matching the filter criteria, or an empty array if
+            none were found.
           schema:
             $ref: '#/definitions/uuid-list-schema'
-        '404':
-          description: No matching job roles were found.
       description: Search for job roles.
     post:
       parameters:
@@ -272,10 +291,16 @@ paths:
           name: body
           required: true
           schema:
-            $ref: '#/definitions/job-role-schema'
+            $ref: '#/definitions/job-role-schema-create'
       responses:
         '201':
           description: The job role was created successfully.
+          headers:
+            Location:
+              type: string
+              description: >
+                The URL at which the newly provisioned job role may be
+                retrieved.
         '400':
           description: The job role was not saved due to malformed JSON.
         '422':
@@ -289,7 +314,8 @@ paths:
         - description: The Invotra UUID of the job role.
           in: path
           name: job_role_id
-          pattern: '^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$'
+          pattern: >-
+            ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
           required: true
           type: string
       responses:
@@ -307,14 +333,15 @@ paths:
         - description: The Invotra UUID of the job role.
           in: path
           name: job_role_id
-          pattern: '^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$'
+          pattern: >-
+            ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
           required: true
           type: string
         - in: body
           name: body
           required: true
           schema:
-            $ref: '#/definitions/job-role-schema-create'
+            $ref: '#/definitions/job-role-schema'
       responses:
         '200':
           description: The job role information was updated successfully.
@@ -327,93 +354,161 @@ paths:
             The job role was not updated due to a Drupal validation failure or a
             JSON schema validation failure.
       description: Update job role information.
+  /locations:
+    get:
+      parameters:
+        - description: Filter by external ID.
+          in: query
+          name: external_id
+          required: true
+          type: string
+      responses:
+        '200':
+          description: >
+            List of locations matching the filter criteria, or an empty array of
+            none were found.
+          schema:
+            $ref: '#/definitions/uuid-list-schema'
+      description: Search for locations.
+    post:
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            $ref: '#/definitions/location-schema-create'
+      responses:
+        '201':
+          description: The location was created successfully.
+          headers:
+            Location:
+              type: string
+              description: >
+                The URL at which the newly provisioned location may be
+                retrieved.
+        '400':
+          description: The location was not saved due to malformed JSON.
+        '422':
+          description: |
+            The location was not saved due to Drupal validation failure or JSON
+            schema validation failure.
+      description: Provision a new location.
+  '/locations/{location_id}':
+    get:
+      parameters:
+        - description: The Invotra UUID of the location.
+          in: path
+          name: location_id
+          pattern: >-
+            ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Returns a single complete location object.
+          schema:
+            $ref: '#/definitions/location-schema'
+        '400':
+          description: The supplied UUID was malformed.
+        '404':
+          description: The UUID does not correspond to an existing location.
+      description: Get information about the location.
+    put:
+      parameters:
+        - description: The Invotra UUID of the location.
+          in: path
+          name: location_id
+          pattern: >-
+            ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
+          required: true
+          type: string
+        - in: body
+          name: body
+          required: true
+          schema:
+            $ref: '#/definitions/location-schema'
+      responses:
+        '200':
+          description: The location information was updated successfully.
+        '400':
+          description: The supplied UUID or JSON was malformed.
+        '404':
+          description: The UUID does not correspond to an existing location.
+        '422':
+          description: |
+            The location was not updated due to a Drupal validation failure or a
+            JSON schema validation failure.
+      description: Update location information.
 definitions:
   team-membership-list-schema:
     properties:
       administrators:
+        allOf:
+          - $ref: '#definitions/uuid-list-schema'
         items:
           description: Invotra UUID of team administrators.
-          pattern: '^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$'
-          type: string
-        type: array
         uniqueItems: true
-      description:
-        description: 'This is a description of the team, optional.'
-        type: string
       members:
+        allOf:
+          - $ref: '#definitions/uuid-list-schema'
         items:
           description: Invotra UUID of team members.
-          pattern: '^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$'
-          type: string
-        type: array
         uniqueItems: true
-      parent_uuid:
-        description: 'This is the Invotra UUID of the parent team, optional.'
-        pattern: '^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$'
-        type: string
-      title:
-        description: This is the name of the team
-        type: string
-      uuid:
-        description: This is the Invotra UUID of the team.
-        pattern: '^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$'
-        type: string
-    required:
-      - uuid
-      - title
     type: object
   team-schema:
     properties:
+      title:
+        description: This is the name of the team
+        type: string
+        example: Operations
       description:
         description: 'This is a description of the team, optional.'
         type: string
+        example: The operations team
       external_id:
         description: This is used to store the team's external reference id
         type: string
+        example: ABC123
       parent_uuid:
         description: 'This is the Invotra UUID of the parent team, optional.'
-        pattern: '^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$'
+        pattern: >-
+          ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
         type: string
-      title:
-        description: This is the name of the team
-        type: string
-      uuid:
-        description: This is the Invotra UUID of the team.
-        pattern: '^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$'
-        type: string
-    required:
-      - uuid
-      - title
+        example: 01234567-89ab-cdef-1234-56789abcdef0
     type: object
   team-schema-create:
-    properties:
-      description:
-        description: 'This is a description of the team, optional.'
-        type: string
-      parent_uuid:
-        description: 'This is the Invotra UUID of the parent team, optional.'
-        pattern: '^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$'
-        type: string
-      title:
-        description: This is the name of the team
-        type: string
+    allOf:
+      - $ref: '#definitions/team-schema'
     required:
       - title
     type: object
   user-schema:
     properties:
+      username:
+        description: The user's username
+        type: string
+        example: drobinson
       email:
         description: Users email address
         format: email
         type: string
+        example: drobinson@example.com
+      external_id:
+        description: The user's external reference ID
+        type: string
+        example: ABC123
       roles:
         items:
           default: Organisational user
           description: This is the default Invotra user role
           enum:
             - Organisational user
+            - Webmaster
           type: string
         type: array
+        example:
+          - Organisational user
+          - Webmaster
         uniqueItems: true
       status:
         default: Active
@@ -422,38 +517,33 @@ definitions:
           - Active
           - Blocked
         type: string
-      username:
-        description: The user's username
-        type: string
-      external_id:
-        description: The user's external reference ID
-        type: string
       home_phone:
         description: The user's home telephone number.
         type: string
+        example: +1-23-456-789
       manager_uuid:
         description: This is the Invotra UUID of the user's manager.
-        pattern: '^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$'
+        pattern: >-
+          ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
         type: string
+        example: 01234567-89ab-cdef-1234-56789abcdef0
       teams:
+        allOf:
+          - $ref: '#definitions/uuid-list-schema'
         items:
-          properties:
-            uuid:
-              description: This is the Invotra UUID for the team.
-              pattern: '^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$'
-              type: string
-          type: object
-        type: array
+          description: An array of UUIDs of the user's teams
       display_name:
-        default: Damian Robinson
+        example: Damian Robinson
         description: Display name for the user
         type: string
       firstname:
         description: The user's first name
         type: string
+        example: Damian
       surname:
         description: The user's surname
         type: string
+        example: Robinson
       title:
         default: ''
         description: The user's title
@@ -465,10 +555,7 @@ definitions:
           - Mrs
           - Ms
         type: string
-      uuid:
-        description: Invotra UUID assigned on creation of the user. Must be included when any updates are made to the user.
-        pattern: '^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$'
-        type: string
+        example: Mr
     type: object
   user-schema-create:
     allOf:
@@ -477,56 +564,66 @@ definitions:
       - email
       - username
     type: object
-  user-schema-update:
-    allOf:
-      - $ref: '#definitions/user-schema'
-    required:
-      - uuid
-    type: object
   job-role-schema:
     properties:
+      title:
+        description: This is the name of the job role
+        type: string
+        example: Director
       description:
         description: 'This is a description of the job role, optional.'
         type: string
+        example: This is a very important job
       external_id:
         description: This is used to store the job role's external reference id
         type: string
+        example: ABC123
       parent_uuid:
         description: 'This is the Invotra UUID of the parent job role, optional.'
-        pattern: '^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$'
+        pattern: >-
+          ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
+        example: 01234567-89ab-cdef-1234-56789abcdef0
         type: string
-      title:
-        description: This is the name of the job role
-        type: string
-      uuid:
-        description: This is the Invotra UUID of the job role.
-        pattern: '^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$'
-        type: string
-    required:
-      - uuid
-      - title
     type: object
   job-role-schema-create:
-    properties:
-      description:
-        description: 'This is a description of the job role, optional.'
-        type: string
-      parent_uuid:
-        description: 'This is the Invotra UUID of the parent job role, optional.'
-        pattern: '^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$'
-        type: string
-      title:
-        description: This is the name of the job role
-        type: string
+    allOf:
+      - $ref: '#definitions/job-role-schema'
     required:
       - title
+  location-schema:
+    properties:
+      title:
+        description: This is the name of the location.
+        type: string
+        example: Dublin
+      description:
+        description: This is a description of the location.
+        type: string
+        example: A beautiful city in Ireland
+      external_id:
+        description: This is used to store the location's external reference id.
+        type: string
+        example: ABC123
+      parent_uuid:
+        description: This is the Invotra UUID of the parent location.
+        pattern: >-
+          ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
+        type: string
+        example: 01234567-89ab-cdef-1234-56789abcdef0
     type: object
+  location-schema-create:
+    allOf:
+      - $ref: '#definitions/location-schema'
+    required:
+      - title
   uuid-list-schema:
     items:
       default: 00000000-0000-0000-0000-000000000000
       description: An array of UUIDs.
-      pattern: '^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$'
+      pattern: >-
+        ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
       type: string
+      example: 01234567-89ab-cdef-1234-56789abcdef0
     type: array
 securityDefinitions:
   APIKeyHeader:


### PR DESCRIPTION
I also tidied up the swagger a bit:
- added examples, and removed one default that should have been an example
- removed UUIDs from the schemas where they are redundant
- fixed some PUT endpoints to use the normal schemas instead of -create
- fixed some POST endpoints to use the -create schemas
- flattened the team memberships schema (hence bumping the version)
- reordered some things to be more logical
- reintroduced 201 Location headers that got lost in conversion from RAML
- removed 404s from search endpoints (we return an empty array)
- maybe some other stuff I forget...