### PR TITLE
NINJA-81 separate raw and rendered description

### DIFF
--- a/api.swagger.yaml
+++ b/api.swagger.yaml
@@ -2680,7 +2680,7 @@ components:
             example: 01234567-89ab-cdef-1234-56789abcdef0
             type: string
           description:
-            description: The HTML-rendered main body of the post. This value is read-only and should not be used for editing - use the source field instead.
+            description: The HTML-rendered main body of the post. Do not use this value for editing - use the value in the source field instead.
             type: string
             example: 'Hey <a href="/users/username" data-mentioned-uuid="1f1397e1-c263-4477-84a0-ca6c1c1560fe">@John Smith</a>, check out the latest <a href="/apps/groups/chat?hashtag=security">#security</a> news in this group!'
           pin:

--- a/api.swagger.yaml
+++ b/api.swagger.yaml
@@ -2679,6 +2679,10 @@ components:
               ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
             example: 01234567-89ab-cdef-1234-56789abcdef0
             type: string
+          description_html:
+            description: The HTML-rendered main body of the post.
+            type: string
+            example: 'Hey <a href="/users/username" data-mentioned-uuid="1f1397e1-c263-4477-84a0-ca6c1c1560fe">@John Smith</a>, check out the latest <a href="/apps/groups/chat?hashtag=security">#security</a> news in this group!'
           pin:
             description: Whether or not this post is pinned.
             type: boolean
@@ -2735,9 +2739,9 @@ components:
     post-schema-base:
       properties:
         description:
-          description: The main body for the post.
+          description: The unrendered main body for the post.
           type: string
-          example: 'Check out the latest #security news in this group!'
+          example: 'Hey [@username], check out the latest #security news in this group!'
         external_id:
           description: This is used to store the post's external reference id
           type: string

--- a/api.swagger.yaml
+++ b/api.swagger.yaml
@@ -2679,7 +2679,7 @@ components:
               ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
             example: 01234567-89ab-cdef-1234-56789abcdef0
             type: string
-          description_html:
+          description:
             description: The HTML-rendered main body of the post.
             type: string
             example: 'Hey <a href="/users/username" data-mentioned-uuid="1f1397e1-c263-4477-84a0-ca6c1c1560fe">@John Smith</a>, check out the latest <a href="/apps/groups/chat?hashtag=security">#security</a> news in this group!'
@@ -2738,8 +2738,8 @@ components:
         - author_uuid
     post-schema-base:
       properties:
-        description:
-          description: The unrendered main body for the post.
+        source:
+          description: The unrendered main body for the post. This value should be used only for editing and is *NOT* safe to display as-is in any HTML context.
           type: string
           example: 'Hey [@username], check out the latest #security news in this group!'
         external_id:

--- a/api.swagger.yaml
+++ b/api.swagger.yaml
@@ -2680,7 +2680,7 @@ components:
             example: 01234567-89ab-cdef-1234-56789abcdef0
             type: string
           description:
-            description: The HTML-rendered main body of the post.
+            description: The HTML-rendered main body of the post. This value is read-only and should not be used for editing - use the source field instead.
             type: string
             example: 'Hey <a href="/users/username" data-mentioned-uuid="1f1397e1-c263-4477-84a0-ca6c1c1560fe">@John Smith</a>, check out the latest <a href="/apps/groups/chat?hashtag=security">#security</a> news in this group!'
           pin:


### PR DESCRIPTION
This changes (or at least, explicitly defines) the `description` field of posts to be rendered HTML, and adds a new `source` field to contain the raw unrendered value of the post body for editing. Since this means `description` is now effectively read-only (being edited indirectly via `source` instead) I'm also removing `description` from non-GET resources to avoid confusion. Sorry if this breaks some things.