### PR TITLE
Update api.swagger.yaml

### DIFF
--- a/api.swagger.yaml
+++ b/api.swagger.yaml
@@ -2649,6 +2649,12 @@ components:
       type: object
     user-schema:
       properties:
+        uuid:
+          description: The UUID of the user
+          pattern: >-
+            ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
+          type: string
+          example: 01234567-89ab-cdef-1234-56789abcdef0
         username:
           description: The user's username
           type: string
@@ -2753,6 +2759,13 @@ components:
           description: The user's job roles. An array of job role names and UUIDs.
           allOf:
             - $ref: '#/components/schemas/title-uuid-list-common-schema'
+        user_uuid:
+          description: The UUID of the user
+          pattern: >-
+            ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
+          type: string
+          example: 01234567-89ab-cdef-1234-56789abcdef0
+          deprecated: true
       type: object
     user-schema-create:
       allOf:

--- a/api.swagger.yaml
+++ b/api.swagger.yaml
@@ -2655,6 +2655,7 @@ components:
             ^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$
           type: string
           example: 01234567-89ab-cdef-1234-56789abcdef0
+          readOnly: true
         username:
           description: The user's username
           type: string
@@ -2766,6 +2767,7 @@ components:
           type: string
           example: 01234567-89ab-cdef-1234-56789abcdef0
           deprecated: true
+          readOnly: true
       type: object
     user-schema-create:
       allOf:


### PR DESCRIPTION
Duplicate value added on purpose. Current Node API returns user_uuid for the app so swagger needs to be in line. In the future we want to standardise to 'uuid' as the label so I've added both and deprecated user_uuid to not introduce breaking changes.