### PR TITLE
PP-99 Removed duplicated property in policy schema

### DIFF
--- a/api.swagger.yaml
+++ b/api.swagger.yaml
@@ -18310,15 +18310,6 @@ components:
             example:
               - 10605
               - 10505
-        confirmed_revision:
-          description: 'The confirmed revisions of the policy.'
-          type: array
-          items:
-            type: number
-            uniqueItems: true
-            example:
-              - 10605
-              - 10505
         current_revision_id:
           description: 'The current revision id'
           type: integer


### PR DESCRIPTION
https://io1dev.atlassian.net/browse/PP-99
Property confirmed_revisions in not exist in invotra-api-nodejs.
There are some duplicated properties:
policy-schema-common contains confirmed_revision.
policy-schema-update extends common schema and contains confirmed_revisions property
policy-schema extends common schema and contains confirmed_revisions property
